### PR TITLE
refactor: session and jwt types

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -56,17 +56,17 @@ export const {
       }
 
       if (token.role && session.user) {
-        session.user.role = token.role as UserRole;
+        session.user.role = token.role;
       }
 
       if (session.user) {
-        session.user.isTwoFactorEnabled = token.isTwoFactorEnabled as boolean;
+        session.user.isTwoFactorEnabled = token.isTwoFactorEnabled;
       }
 
       if (session.user) {
         session.user.name = token.name;
         session.user.email = token.email;
-        session.user.isOAuth = token.isOAuth as boolean;
+        session.user.isOAuth = token.isOAuth;
       }
 
       return session;

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,14 +1,22 @@
 import { UserRole } from "@prisma/client";
-import NextAuth, { type DefaultSession } from "next-auth";
 
-export type ExtendedUser = DefaultSession["user"] & {
-  role: UserRole;
-  isTwoFactorEnabled: boolean;
-  isOAuth: boolean;
-};
+import type { JWT } from "@auth/core/jwt";
+import type { Session } from "@auth/core/types";
 
-declare module "next-auth" {
+declare module "@auth/core/jwt" {
+  interface JWT {
+    role: UserRole;
+    isTwoFactorEnabled: boolean;
+    isOAuth: boolean;
+  }
+}
+
+declare module "@auth/core/types" {
   interface Session {
-    user: ExtendedUser;
+    user: {
+      role: UserRole;
+      isTwoFactorEnabled: boolean;
+      isOAuth: boolean;
+    } & Session["user"];
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "auth-tutorial",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
+        "@auth/core": "^0.18.4",
         "@auth/prisma-adapter": "^1.0.12",
         "@hookform/resolvers": "^3.3.3",
         "@prisma/client": "^5.7.1",
@@ -75,15 +77,14 @@
       }
     },
     "node_modules/@auth/core": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.19.0.tgz",
-      "integrity": "sha512-BkFg2SoNftMN6A2Sn2g1lLFLTO74qMtFKsZmSCEF9d1csqSaEXIv50k6OrfniODWi5tZP8bcfSxGodv75khlOA==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.18.4.tgz",
+      "integrity": "sha512-GsNhsP1xE/3FoNS3dVkPjqRljLNJ4iyL2OLv3klQGNvw3bMpROFcK4lqhx7+pPHiamnVaYt2vg1xbB+lsNaevg==",
       "dependencies": {
         "@panva/hkdf": "^1.1.1",
-        "@types/cookie": "0.6.0",
         "cookie": "0.6.0",
-        "jose": "^5.1.3",
-        "oauth4webapi": "^2.4.0",
+        "jose": "^5.1.0",
+        "oauth4webapi": "^2.3.0",
         "preact": "10.11.3",
         "preact-render-to-string": "5.2.3"
       },
@@ -105,6 +106,28 @@
       },
       "peerDependencies": {
         "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5"
+      }
+    },
+    "node_modules/@auth/prisma-adapter/node_modules/@auth/core": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.19.0.tgz",
+      "integrity": "sha512-BkFg2SoNftMN6A2Sn2g1lLFLTO74qMtFKsZmSCEF9d1csqSaEXIv50k6OrfniODWi5tZP8bcfSxGodv75khlOA==",
+      "dependencies": {
+        "@panva/hkdf": "^1.1.1",
+        "@types/cookie": "0.6.0",
+        "cookie": "0.6.0",
+        "jose": "^5.1.3",
+        "oauth4webapi": "^2.4.0",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/runtime": {
@@ -4607,27 +4630,6 @@
         "next": "^14",
         "nodemailer": "^6.6.5",
         "react": "^18.2.0"
-      },
-      "peerDependenciesMeta": {
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/next-auth/node_modules/@auth/core": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.18.4.tgz",
-      "integrity": "sha512-GsNhsP1xE/3FoNS3dVkPjqRljLNJ4iyL2OLv3klQGNvw3bMpROFcK4lqhx7+pPHiamnVaYt2vg1xbB+lsNaevg==",
-      "dependencies": {
-        "@panva/hkdf": "^1.1.1",
-        "cookie": "0.6.0",
-        "jose": "^5.1.0",
-        "oauth4webapi": "^2.3.0",
-        "preact": "10.11.3",
-        "preact-render-to-string": "5.2.3"
-      },
-      "peerDependencies": {
-        "nodemailer": "^6.8.0"
       },
       "peerDependenciesMeta": {
         "nodemailer": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postinstall": "prisma generate"
   },
   "dependencies": {
+    "@auth/core": "^0.18.4",
     "@auth/prisma-adapter": "^1.0.12",
     "@hookform/resolvers": "^3.3.3",
     "@prisma/client": "^5.7.1",


### PR DESCRIPTION
I removed redundant type parsings and installed `@auth/core` to extend JWT types, following the deprecation of `next-auth/jwt` in `next-auth@5`.